### PR TITLE
Release for v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.1.8](https://github.com/takaiyuk/grrs/compare/v0.1.7...v0.1.8) - 2023-12-19
+- Add env for release to github by @takaiyuk in https://github.com/takaiyuk/grrs/pull/32
+
 ## [v0.1.7](https://github.com/takaiyuk/grrs/compare/v0.1.6...v0.1.7) - 2023-12-19
 - downgrade upload-artifact version by @takaiyuk in https://github.com/takaiyuk/grrs/pull/30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "takaiyuk-grrs"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "takaiyuk-grrs"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["tishikawa"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This pull request is for the next release as v0.1.8 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.8 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Add env for release to github by @takaiyuk in https://github.com/takaiyuk/grrs/pull/32


**Full Changelog**: https://github.com/takaiyuk/grrs/compare/v0.1.7...v0.1.8